### PR TITLE
Fix PyPI authentication to use API tokens

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
           command: |
             pip install build twine
             python -m build
-            python -m twine upload --repository testpypi dist/*
+            python -m twine upload --repository testpypi dist/* --username __token__ --password $TESTPYPI_API_TOKEN
 
   pypi-publish:
     docker:
@@ -64,7 +64,7 @@ jobs:
           command: |
             pip install build twine
             python -m build
-            python -m twine upload dist/*
+            python -m twine upload dist/* --username __token__ --password $PYPI_API_TOKEN
 
 # Orchestrate jobs using workflows
 # See: https://circleci.com/docs/workflows/ & https://circleci.com/docs/configuration-reference/#workflows


### PR DESCRIPTION
- Replace deprecated username/password auth with API token method
- Use __token__ as username and API tokens from environment variables
- Requires PYPI_API_TOKEN and TESTPYPI_API_TOKEN to be set in CircleCI
- This resolves the 403 Forbidden authentication error