### PR TITLE
Fix JOIN on multiple conditions with AND operator

### DIFF
--- a/tests/test_join_on.py
+++ b/tests/test_join_on.py
@@ -25,3 +25,19 @@ class TestJoinOn(TestCase):
         ans = pipeline.parse()
         expected = """final_df = Test.alias("t1").join(Test.alias("t2"), col("t1.id")==col("t2.id"), "left")\\\n.selectExpr("t1.id AS id","t1.val AS t1_val","t2.val AS t1_val")\n\n"""
         self.assertEqual(ans, expected)
+
+    def test_multiple_join_conditions(self):
+        """Test JOIN with multiple conditions using AND"""
+        sql = """
+        SELECT 
+            t1.id as id, 
+            t1.val as t1_val,
+            t2.val as t2_val
+        FROM Test t1
+        LEFT JOIN Test t2
+        ON t1.id = t2.id AND t1.id2 = t2.id2
+        """
+        pipeline = Pipeline(sql)
+        ans = pipeline.parse()
+        expected = """final_df = Test.alias("t1").join(Test.alias("t2"), col("t1.id")==col("t2.id") & col("t1.id2")==col("t2.id2"), "left")\\\n.selectExpr("t1.id AS id","t1.val AS t1_val","t2.val AS t2_val")\n\n"""
+        self.assertEqual(ans, expected)


### PR DESCRIPTION
Fixes #7

This PR resolves the issue where JOIN queries with multiple conditions using AND would fail with a KeyError.

## Changes
- Added `_joinfeat` helper method to handle both single and multiple JOIN conditions
- Updated `_from_analyze` to use the new helper method for all JOIN types
- Added comprehensive test case for multiple JOIN conditions

## Testing
The fix handles queries like:
```sql
SELECT * FROM Test t1 LEFT JOIN Test t2 ON t1.id = t2.id AND t1.id2 = t2.id2
```

Generated with [Claude Code](https://claude.ai/code)